### PR TITLE
Maintain requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,16 @@
 # This file may be used to create an environment using:
 # $ conda create --name <env> --file <this file>
 # platform: osx-64
-streamlit
-pandas
-geopandas
-folium
-streamlit_folium
+streamlit == 1.38.0
+pandas == 2.2.2
+geopandas == 1.0.1
+folium == 0.17.0
+streamlit_folium == 0.22.0
 numpy == 1.26.4
-scipy
-pandasai
+scipy == 1.14.1
+pandasai == 2.0.24
 google-generativeai
-pyyaml
-fuzzywuzzy
-mapclassify
-numba
+pyyaml == 6.0.2
+fuzzywuzzy == 0.18.0
+mapclassify == 2.8.0
+numba == 0.60.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pandas
 geopandas
 folium
 streamlit_folium
-numpy
+numpy == 1.26.4
 scipy
 pandasai
 google-generativeai


### PR DESCRIPTION
Error when attempting to deploy app on streamlit was due to the following error
```
ValueError: numpy.dtype size changed, may indicate binary incompatibility. 
Expected 96 from C header, got 88 from PyObject
```

Cause found to be incompatible versions, notably numpy being over 2.*, leading to downgrading and setting numpy to use version 1.26.4. After doing so, app was seen to be running as normal. Have provided version numbers of all packages in requirements.txt based on current working app. 

Debug process:
 - Create app in streamlit.io
 - Ensure Python version being used is 3.11 through advanced settings on app creation
 - Define secrets from .env
 - View 'Manage App' modal in bottom right corner and click it to see a running log of the streamlit app. Any logs or errors will be displayed there
 - Find error and troubleshoot

